### PR TITLE
heredoc : corrected leaks

### DIFF
--- a/srcs/constructors.c
+++ b/srcs/constructors.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   constructors.c                                     :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: facu <facu@student.42.fr>                  +#+  +:+       +#+        */
+/*   By: amak <amak@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/22 17:19:55 by ftroiter          #+#    #+#             */
-/*   Updated: 2023/12/04 10:55:10 by facu             ###   ########.fr       */
+/*   Updated: 2023/12/10 18:32:59 by amak             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -58,5 +58,6 @@ t_node	*heredoccmd(t_node *execnode, char *delimiter)
 	node->type = HEREDOC;
 	node->execnode = execnode;
 	node->fd = read_heredoc(delimiter);
+	free(delimiter);
 	return ((t_node *)node);
 }

--- a/srcs/read.c
+++ b/srcs/read.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   read.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: facu <facu@student.42.fr>                  +#+  +:+       +#+        */
+/*   By: amak <amak@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/23 18:07:29 by facu              #+#    #+#             */
-/*   Updated: 2023/12/04 22:36:55 by facu             ###   ########.fr       */
+/*   Updated: 2023/12/10 18:34:38 by amak             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -36,6 +36,7 @@ int	read_heredoc(char *delimiter)
             break;
         write(fd[1], line, ft_strlen(line));
         write(fd[1], "\n", 1);
+		free(line);
 	}
 	free(line);
 	close(fd[1]);


### PR DESCRIPTION
read.c -  read_heredoc:  has to free the line each time from the prompt readline and when the line is the delimiter.
constructors.c: heredoccmd: after reading each line and sending to FD, have tro free the delimiter string.

tested command: valgrind ./minishell
 
wc << EOF